### PR TITLE
Refactoring of the videostore

### DIFF
--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -16,7 +16,7 @@ import (
 	"github.com/odwrtw/polochon/app/internal/server"
 	"github.com/odwrtw/polochon/app/internal/subapp"
 	"github.com/odwrtw/polochon/app/internal/token"
-	"github.com/odwrtw/polochon/lib"
+	"github.com/odwrtw/polochon/lib/library"
 )
 
 // App represents the polochon app
@@ -82,19 +82,19 @@ func (a *App) init() error {
 		return err
 	}
 
-	videoStore := polochon.NewVideoStore(config.File, config.Movie, config.Show, config.VideoStore)
+	library := library.NewVideoStore(config.File, config.Movie, config.Show, config.VideoStore)
 
-	// Build the videoStore index
-	if err := videoStore.RebuildIndex(log); err != nil {
+	// Build the library index
+	if err := library.RebuildIndex(log); err != nil {
 		log.WithField("function", "rebuild_index").Error(err)
 	}
 
 	// Add the organizer
-	a.subApps = []subapp.App{organizer.New(config, videoStore)}
+	a.subApps = []subapp.App{organizer.New(config, library)}
 
 	if config.Downloader.Enabled {
 		// Add the downloader
-		a.subApps = append(a.subApps, downloader.New(config, videoStore))
+		a.subApps = append(a.subApps, downloader.New(config, library))
 
 		if config.Downloader.Cleaner.Enabled {
 			// Add the cleaner
@@ -123,7 +123,7 @@ func (a *App) init() error {
 		}
 
 		// Add the http server
-		a.subApps = append(a.subApps, server.New(config, videoStore, tokenManager))
+		a.subApps = append(a.subApps, server.New(config, library, tokenManager))
 	}
 
 	log.Debug("app configuration loaded")

--- a/app/internal/app/app.go
+++ b/app/internal/app/app.go
@@ -82,7 +82,7 @@ func (a *App) init() error {
 		return err
 	}
 
-	library := library.NewVideoStore(config.File, config.Movie, config.Show, config.VideoStore)
+	library := library.New(config.File, config.Movie, config.Show, config.Library)
 
 	// Build the library index
 	if err := library.RebuildIndex(log); err != nil {

--- a/app/internal/configuration/configuration.go
+++ b/app/internal/configuration/configuration.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/odwrtw/polochon/lib"
+	"github.com/odwrtw/polochon/lib/library"
 	"gopkg.in/yaml.v2"
 )
 
@@ -125,7 +126,7 @@ type Config struct {
 	Movie         polochon.MovieConfig
 	Show          polochon.ShowConfig
 	File          polochon.FileConfig
-	VideoStore    polochon.VideoStoreConfig
+	VideoStore    library.VideoStoreConfig
 	Notifiers     []polochon.Notifier
 }
 
@@ -260,7 +261,7 @@ func loadConfig(cf *ConfigFileRoot, log *logrus.Entry) (*Config, error) {
 		return nil, err
 	}
 
-	conf.VideoStore = polochon.VideoStoreConfig{
+	conf.VideoStore = library.VideoStoreConfig{
 		MovieDir: realMoviesPath,
 		ShowDir:  realShowsPath,
 	}

--- a/app/internal/configuration/configuration.go
+++ b/app/internal/configuration/configuration.go
@@ -126,7 +126,7 @@ type Config struct {
 	Movie         polochon.MovieConfig
 	Show          polochon.ShowConfig
 	File          polochon.FileConfig
-	VideoStore    library.VideoStoreConfig
+	Library       library.Config
 	Notifiers     []polochon.Notifier
 }
 
@@ -261,7 +261,7 @@ func loadConfig(cf *ConfigFileRoot, log *logrus.Entry) (*Config, error) {
 		return nil, err
 	}
 
-	conf.VideoStore = library.VideoStoreConfig{
+	conf.Library = library.Config{
 		MovieDir: realMoviesPath,
 		ShowDir:  realShowsPath,
 	}

--- a/app/internal/downloader/downloader.go
+++ b/app/internal/downloader/downloader.go
@@ -19,12 +19,12 @@ type Downloader struct {
 	*subapp.Base
 
 	config  *configuration.Config
-	library *library.VideoStore
+	library *library.Library
 	event   chan struct{}
 }
 
 // New returns a new downloader
-func New(config *configuration.Config, vs *library.VideoStore) *Downloader {
+func New(config *configuration.Config, vs *library.Library) *Downloader {
 	return &Downloader{
 		Base:    subapp.NewBase(AppName),
 		config:  config,

--- a/app/internal/downloader/downloader.go
+++ b/app/internal/downloader/downloader.go
@@ -8,6 +8,7 @@ import (
 	"github.com/odwrtw/polochon/app/internal/configuration"
 	"github.com/odwrtw/polochon/app/internal/subapp"
 	"github.com/odwrtw/polochon/lib"
+	"github.com/odwrtw/polochon/lib/library"
 )
 
 // AppName is the application name
@@ -17,17 +18,17 @@ const AppName = "downloader"
 type Downloader struct {
 	*subapp.Base
 
-	config     *configuration.Config
-	videoStore *polochon.VideoStore
-	event      chan struct{}
+	config  *configuration.Config
+	library *library.VideoStore
+	event   chan struct{}
 }
 
 // New returns a new downloader
-func New(config *configuration.Config, vs *polochon.VideoStore) *Downloader {
+func New(config *configuration.Config, vs *library.VideoStore) *Downloader {
 	return &Downloader{
-		Base:       subapp.NewBase(AppName),
-		config:     config,
-		videoStore: vs,
+		Base:    subapp.NewBase(AppName),
+		config:  config,
+		library: vs,
 	}
 }
 
@@ -124,7 +125,7 @@ func (d *Downloader) downloadMissingMovies(wl *polochon.Wishlist, log *logrus.En
 	log = log.WithField("function", "download_movies")
 
 	for _, wantedMovie := range wl.Movies {
-		ok, err := d.videoStore.HasMovie(wantedMovie.ImdbID)
+		ok, err := d.library.HasMovie(wantedMovie.ImdbID)
 		if err != nil {
 			log.Error(err)
 			continue
@@ -209,7 +210,7 @@ func (d *Downloader) downloadMissingShows(wl *polochon.Wishlist, log *logrus.Ent
 			}
 
 			// Check if the episode has already been downloaded
-			ok, err := d.videoStore.HasShowEpisode(wishedShow.ImdbID, calEpisode.Season, calEpisode.Episode)
+			ok, err := d.library.HasShowEpisode(wishedShow.ImdbID, calEpisode.Season, calEpisode.Episode)
 			if err != nil {
 				log.Error(err)
 				continue

--- a/app/internal/organizer/organizer.go
+++ b/app/internal/organizer/organizer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/odwrtw/polochon/app/internal/configuration"
 	"github.com/odwrtw/polochon/app/internal/subapp"
 	"github.com/odwrtw/polochon/lib"
+	"github.com/odwrtw/polochon/lib/library"
 )
 
 // AppName is the application name
@@ -18,17 +19,17 @@ const AppName = "organizer"
 type Organizer struct {
 	*subapp.Base
 
-	config     *configuration.Config
-	videoStore *polochon.VideoStore
-	event      chan string
+	config  *configuration.Config
+	library *library.VideoStore
+	event   chan string
 }
 
 // New returns a new organizer
-func New(config *configuration.Config, vs *polochon.VideoStore) *Organizer {
+func New(config *configuration.Config, vs *library.VideoStore) *Organizer {
 	return &Organizer{
-		Base:       subapp.NewBase(AppName),
-		config:     config,
-		videoStore: vs,
+		Base:    subapp.NewBase(AppName),
+		config:  config,
+		library: vs,
 	}
 }
 
@@ -173,7 +174,7 @@ func (o *Organizer) organizeFile(filePath string, log *logrus.Entry) error {
 	}
 
 	// Store the video
-	if err := o.videoStore.Add(video, log); err != nil {
+	if err := o.library.Add(video, log); err != nil {
 		errors.LogErrors(log, err)
 		return file.Ignore()
 	}

--- a/app/internal/organizer/organizer.go
+++ b/app/internal/organizer/organizer.go
@@ -20,12 +20,12 @@ type Organizer struct {
 	*subapp.Base
 
 	config  *configuration.Config
-	library *library.VideoStore
+	library *library.Library
 	event   chan string
 }
 
 // New returns a new organizer
-func New(config *configuration.Config, vs *library.VideoStore) *Organizer {
+func New(config *configuration.Config, vs *library.Library) *Organizer {
 	return &Organizer{
 		Base:    subapp.NewBase(AppName),
 		config:  config,

--- a/app/internal/server/http.go
+++ b/app/internal/server/http.go
@@ -28,7 +28,7 @@ type Server struct {
 	*subapp.Base
 
 	config         *configuration.Config
-	library        *library.VideoStore
+	library        *library.Library
 	tokenManager   *token.Manager
 	gracefulServer *manners.GracefulServer
 	log            *logrus.Entry
@@ -36,7 +36,7 @@ type Server struct {
 }
 
 // New returns a new server
-func New(config *configuration.Config, vs *library.VideoStore, tm *token.Manager) *Server {
+func New(config *configuration.Config, vs *library.Library, tm *token.Manager) *Server {
 	return &Server{
 		Base:         subapp.NewBase(AppName),
 		config:       config,

--- a/app/internal/server/http.go
+++ b/app/internal/server/http.go
@@ -5,19 +5,16 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
-	"strconv"
 
 	"gopkg.in/unrolled/render.v1"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/braintree/manners"
-	"github.com/gorilla/mux"
 	"github.com/odwrtw/polochon/app/internal/configuration"
 	"github.com/odwrtw/polochon/app/internal/subapp"
 	"github.com/odwrtw/polochon/app/internal/token"
 	"github.com/odwrtw/polochon/lib"
 	"github.com/odwrtw/polochon/lib/library"
-	"github.com/odwrtw/polochon/lib/media_index"
 )
 
 // AppName is the application name
@@ -67,129 +64,6 @@ func (s *Server) BlockingStop(log *logrus.Entry) {
 	s.gracefulServer.BlockingClose()
 }
 
-func (s *Server) movieIds(w http.ResponseWriter, req *http.Request) {
-	s.log.Debug("listing movies by ids")
-
-	movieIds, err := s.library.MovieIds()
-	if err != nil {
-		s.renderError(w, err)
-		return
-	}
-	s.renderOK(w, movieIds)
-}
-
-func (s *Server) getMovieDetails(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	id := vars["id"]
-
-	s.log.Debugf("looking for a movie with ID %q", id)
-
-	// Find the file
-	v, err := s.library.SearchMovieByImdbID(id)
-	if err != nil {
-		s.log.Error(err)
-		var status int
-		if err == index.ErrNotFound {
-			status = http.StatusNotFound
-		} else {
-			status = http.StatusInternalServerError
-		}
-		s.renderError(w, &Error{
-			Code:    status,
-			Message: "URL not found",
-		})
-		return
-	}
-
-	s.renderOK(w, v)
-}
-
-func (s *Server) showIds(w http.ResponseWriter, req *http.Request) {
-	s.log.Debug("listing shows")
-
-	ids, err := s.library.ShowIds()
-	if err != nil {
-		s.renderError(w, err)
-		return
-	}
-
-	ret := map[string]map[string][]string{}
-	for id, show := range ids {
-		ret[id] = map[string][]string{}
-		for seasonNum, season := range show.Seasons {
-			s := fmt.Sprintf("%02d", seasonNum)
-			for episode := range season.Episodes {
-				e := fmt.Sprintf("%02d", episode)
-
-				if _, ok := ret[id][s]; !ok {
-					ret[id][s] = []string{}
-				}
-
-				ret[id][s] = append(ret[id][s], e)
-			}
-		}
-	}
-
-	s.renderOK(w, ret)
-}
-
-func (s *Server) getShowDetails(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	v, err := s.library.NewShowFromID(vars["id"])
-	if err != nil {
-		s.log.Error(err)
-		var status int
-		if err == index.ErrNotFound {
-			status = http.StatusNotFound
-		} else {
-			status = http.StatusInternalServerError
-		}
-		s.renderError(w, &Error{
-			Code:    status,
-			Message: "URL not found",
-		})
-		return
-	}
-
-	s.renderOK(w, v)
-}
-
-func (s *Server) getShowEpisodeIDDetails(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-
-	var season, episode int
-	for ptr, str := range map[*int]string{
-		&season:  vars["season"],
-		&episode: vars["episode"],
-	} {
-		v, err := strconv.Atoi(str)
-		if err != nil {
-			s.renderError(w, fmt.Errorf("invalid season or episode"))
-			return
-		}
-		*ptr = v
-	}
-
-	v, err := s.library.SearchShowEpisodeByImdbID(vars["id"], season, episode)
-	if err != nil {
-		s.log.Error(err)
-		var status int
-		if err == index.ErrNotFound {
-			status = http.StatusNotFound
-		} else {
-			status = http.StatusInternalServerError
-		}
-		s.renderError(w, &Error{
-			Code:    status,
-			Message: "URL not found",
-		})
-		return
-	}
-
-	s.renderOK(w, v)
-}
-
 func (s *Server) wishlist(w http.ResponseWriter, req *http.Request) {
 	wl := polochon.NewWishlist(s.config.Wishlist, s.log)
 
@@ -201,60 +75,10 @@ func (s *Server) wishlist(w http.ResponseWriter, req *http.Request) {
 	s.renderOK(w, wl)
 }
 
-func serveFile(w http.ResponseWriter, r *http.Request, file *polochon.File) {
+func (s *Server) serveFile(w http.ResponseWriter, r *http.Request, file *polochon.File) {
 	// Set the header so that when downloading, the real filename will be given
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(file.Path)))
 	http.ServeFile(w, r, file.Path)
-}
-
-func (s *Server) serveMovie(w http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	v, err := s.library.SearchMovieByImdbID(vars["id"])
-	s.serveVideo(w, req, v, err)
-}
-
-func (s *Server) serveShow(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	if vars["id"] == "" && vars["season"] == "" && vars["episode"] == "" {
-		s.renderError(w, &Error{
-			Code:    http.StatusNotFound,
-			Message: "URL not found",
-		})
-	}
-
-	season, err := strconv.Atoi(vars["season"])
-	if err != nil {
-		s.renderError(w, err)
-		return
-	}
-
-	episode, err := strconv.Atoi(vars["episode"])
-	if err != nil {
-		s.renderError(w, err)
-		return
-	}
-
-	v, err := s.library.SearchShowEpisodeByImdbID(vars["id"], season, episode)
-	s.serveVideo(w, r, v, err)
-}
-
-func (s *Server) serveVideo(w http.ResponseWriter, r *http.Request, v polochon.Video, err error) {
-	if err != nil {
-		s.log.Error(err)
-		var status int
-		if err == index.ErrNotFound {
-			status = http.StatusNotFound
-		} else {
-			status = http.StatusInternalServerError
-		}
-		s.renderError(w, &Error{
-			Code:    status,
-			Message: err.Error(),
-		})
-		return
-	}
-
-	serveFile(w, r, v.GetFile())
 }
 
 func (s *Server) addTorrent(w http.ResponseWriter, r *http.Request) {

--- a/app/internal/server/http.go
+++ b/app/internal/server/http.go
@@ -131,6 +131,28 @@ func (s *Server) showIds(w http.ResponseWriter, req *http.Request) {
 	s.renderOK(w, ret)
 }
 
+func (s *Server) getShowDetails(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	v, err := s.videoStore.NewShowFromID(vars["id"])
+	if err != nil {
+		s.log.Error(err)
+		var status int
+		if err == polochon.ErrImdbIDNotFound {
+			status = http.StatusNotFound
+		} else {
+			status = http.StatusInternalServerError
+		}
+		s.renderError(w, &Error{
+			Code:    status,
+			Message: "URL not found",
+		})
+		return
+	}
+
+	s.renderOK(w, v)
+}
+
 func (s *Server) getShowEpisodeIDDetails(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 

--- a/app/internal/server/movies.go
+++ b/app/internal/server/movies.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/odwrtw/polochon/lib"
+	"github.com/odwrtw/polochon/lib/media_index"
+)
+
+func (s *Server) movieIds(w http.ResponseWriter, req *http.Request) {
+	s.log.Debug("listing movies by ids")
+
+	movieIds, err := s.library.MovieIds()
+	if err != nil {
+		s.renderError(w, err)
+		return
+	}
+	s.renderOK(w, movieIds)
+}
+
+// TODO: handle this in a middleware
+func (s *Server) getMovie(w http.ResponseWriter, req *http.Request) *polochon.Movie {
+	vars := mux.Vars(req)
+	id := vars["id"]
+
+	s.log.Debugf("looking for a movie with ID %q", id)
+
+	// Find the file
+	v, err := s.library.SearchMovieByImdbID(id)
+	if err != nil {
+		s.log.Error(err)
+		var status int
+		if err == index.ErrNotFound {
+			status = http.StatusNotFound
+		} else {
+			status = http.StatusInternalServerError
+		}
+		s.renderError(w, &Error{
+			Code:    status,
+			Message: "URL not found",
+		})
+		return nil
+	}
+
+	m, ok := v.(*polochon.Movie)
+	if !ok {
+		s.renderError(w, &Error{
+			Code:    http.StatusInternalServerError,
+			Message: "invalid type",
+		})
+		return nil
+	}
+
+	return m
+}
+
+func (s *Server) getMovieDetails(w http.ResponseWriter, req *http.Request) {
+	m := s.getMovie(w, req)
+	if m == nil {
+		return
+	}
+
+	s.renderOK(w, m)
+}
+
+func (s *Server) serveMovie(w http.ResponseWriter, req *http.Request) {
+	m := s.getMovie(w, req)
+	if m == nil {
+		return
+	}
+
+	s.serveFile(w, req, m.GetFile())
+}
+
+func (s *Server) deleteMovie(w http.ResponseWriter, req *http.Request) {
+	m := s.getMovie(w, req)
+	if m == nil {
+		return
+	}
+
+	if err := s.library.Delete(m, s.log); err != nil {
+		s.renderError(w, &Error{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	s.renderOK(w, nil)
+}

--- a/app/internal/server/routes.go
+++ b/app/internal/server/routes.go
@@ -19,20 +19,22 @@ func (s *Server) httpServer(log *logrus.Entry) *http.Server {
 
 	mux := mux.NewRouter()
 
-	mux.HandleFunc("/movies", s.movieIds).Name("MoviesListIDs")
-	mux.HandleFunc("/movies/{id}", s.getMovieDetails).Name("GetMovieDetails")
+	mux.HandleFunc("/movies", s.movieIds).Name("MoviesListIDs").Methods("GET")
+	mux.HandleFunc("/movies/{id}", s.getMovieDetails).Name("GetMovieDetails").Methods("GET")
+	mux.HandleFunc("/movies/{id}", s.deleteMovie).Name("DeleteMovie").Methods("DELETE")
 
-	mux.HandleFunc("/shows", s.showIds).Name("ShowsListIDs")
-	mux.HandleFunc("/shows/{id}", s.getShowDetails).Name("GetShowDetails")
-	mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}", s.getShowEpisodeIDDetails).Name("GetShowEpisodeIDDetails")
-	mux.HandleFunc("/wishlist", s.wishlist).Name("Wishlist")
+	mux.HandleFunc("/shows", s.showIds).Name("ShowsListIDs").Methods("GET")
+	mux.HandleFunc("/shows/{id}", s.getShowDetails).Name("GetShowDetails").Methods("GET")
+	mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}", s.getShowEpisodeIDDetails).Name("GetShowEpisodeIDDetails").Methods("GET")
+	mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}", s.deleteEpisode).Name("DeleteEpisode").Methods("DELETE")
+	mux.HandleFunc("/wishlist", s.wishlist).Name("Wishlist").Methods("GET")
 
-	mux.HandleFunc("/torrents", s.addTorrent).Methods("POST").Name("TorrentsAdd")
+	mux.HandleFunc("/torrents", s.addTorrent).Name("TorrentsAdd").Methods("POST")
 
 	if s.config.HTTPServer.ServeFiles {
 		log.Debug("server will be serving files")
-		mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}/download", s.serveShow).Name("ServeShowsByIDs")
-		mux.HandleFunc("/movies/{id}/download", s.serveMovie).Name("ServeMoviesByIDs")
+		mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}/download", s.serveShow).Name("ServeShowsByIDs").Methods("GET")
+		mux.HandleFunc("/movies/{id}/download", s.serveMovie).Name("ServeMoviesByIDs").Methods("GET")
 	}
 
 	n := negroni.New()

--- a/app/internal/server/routes.go
+++ b/app/internal/server/routes.go
@@ -19,25 +19,19 @@ func (s *Server) httpServer(log *logrus.Entry) *http.Server {
 
 	mux := mux.NewRouter()
 
-	mux.HandleFunc("/movies/slugs", s.movieSlugs).Name("MoviesListSlugs")
-	mux.HandleFunc("/movies/ids", s.movieIds).Name("MoviesListIDs")
-	mux.HandleFunc("/movies/{idType:ids|slugs}/{id}", s.getMovieDetails).Name("GetMovieDetails")
+	mux.HandleFunc("/movies", s.movieIds).Name("MoviesListIDs")
+	mux.HandleFunc("/movies/{id}", s.getMovieDetails).Name("GetMovieDetails")
 
-	mux.HandleFunc("/shows/ids", s.showIds).Name("ShowsListIDs")
-	mux.HandleFunc("/shows/slugs", s.showSlugs).Name("ShowsListSlugs")
-	mux.HandleFunc("/shows/slugs/{slug}", s.getShowEpisodeSlugDetails).Name("GetShowEpisodeSlugDetails")
-	mux.HandleFunc("/shows/ids/{id}/{season:[0-9]+}/{episode:[0-9]+}", s.getShowEpisodeIDDetails).Name("GetShowEpisodeIDDetails")
+	mux.HandleFunc("/shows", s.showIds).Name("ShowsListIDs")
+	mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}", s.getShowEpisodeIDDetails).Name("GetShowEpisodeIDDetails")
 	mux.HandleFunc("/wishlist", s.wishlist).Name("Wishlist")
 
 	mux.HandleFunc("/torrents", s.addTorrent).Methods("POST").Name("TorrentsAdd")
 
 	if s.config.HTTPServer.ServeFiles {
 		log.Debug("server will be serving files")
-		mux.HandleFunc("/{videoType:movies|shows}/slugs/{slug}/delete", s.deleteFile).Name("DeleteBySlugs")
-		mux.HandleFunc("/shows/slugs/{slug}/download", s.serveShow).Name("ServeShowsBySlugs")
-		mux.HandleFunc("/shows/ids/{id}/{season}/{episode}/download", s.serveShow).Name("ServeShowsByIDs")
-		mux.HandleFunc("/movies/ids/{id}/download", s.serveMovie).Name("ServeMoviesByIDs")
-		mux.HandleFunc("/movies/slugs/{slug}/download", s.serveMovie).Name("ServeMoviesBySlugs")
+		mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}/download", s.serveShow).Name("ServeShowsByIDs")
+		mux.HandleFunc("/movies/{id}/download", s.serveMovie).Name("ServeMoviesByIDs")
 	}
 
 	n := negroni.New()

--- a/app/internal/server/routes.go
+++ b/app/internal/server/routes.go
@@ -23,6 +23,7 @@ func (s *Server) httpServer(log *logrus.Entry) *http.Server {
 	mux.HandleFunc("/movies/{id}", s.getMovieDetails).Name("GetMovieDetails")
 
 	mux.HandleFunc("/shows", s.showIds).Name("ShowsListIDs")
+	mux.HandleFunc("/shows/{id}", s.getShowDetails).Name("GetShowDetails")
 	mux.HandleFunc("/shows/{id}/{season:[0-9]+}/{episode:[0-9]+}", s.getShowEpisodeIDDetails).Name("GetShowEpisodeIDDetails")
 	mux.HandleFunc("/wishlist", s.wishlist).Name("Wishlist")
 

--- a/app/internal/server/shows.go
+++ b/app/internal/server/shows.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/odwrtw/polochon/lib"
+	"github.com/odwrtw/polochon/lib/media_index"
+)
+
+func (s *Server) showIds(w http.ResponseWriter, req *http.Request) {
+	s.log.Debug("listing shows")
+
+	ids, err := s.library.ShowIds()
+	if err != nil {
+		s.renderError(w, err)
+		return
+	}
+
+	ret := map[string]map[string][]string{}
+	for id, show := range ids {
+		ret[id] = map[string][]string{}
+		for seasonNum, season := range show.Seasons {
+			s := fmt.Sprintf("%02d", seasonNum)
+			for episode := range season.Episodes {
+				e := fmt.Sprintf("%02d", episode)
+
+				if _, ok := ret[id][s]; !ok {
+					ret[id][s] = []string{}
+				}
+
+				ret[id][s] = append(ret[id][s], e)
+			}
+		}
+	}
+
+	s.renderOK(w, ret)
+}
+
+// TODO: handle this in a middleware
+func (s *Server) getEpisode(w http.ResponseWriter, req *http.Request) *polochon.ShowEpisode {
+	vars := mux.Vars(req)
+
+	var season, episode int
+	for ptr, str := range map[*int]string{
+		&season:  vars["season"],
+		&episode: vars["episode"],
+	} {
+		v, err := strconv.Atoi(str)
+		if err != nil {
+			s.renderError(w, fmt.Errorf("invalid season or episode"))
+			return nil
+		}
+		*ptr = v
+	}
+
+	v, err := s.library.SearchShowEpisodeByImdbID(vars["id"], season, episode)
+	if err != nil {
+		s.log.Error(err)
+		var status int
+		if err == index.ErrNotFound {
+			status = http.StatusNotFound
+		} else {
+			status = http.StatusInternalServerError
+		}
+		s.renderError(w, &Error{
+			Code:    status,
+			Message: "URL not found",
+		})
+		return nil
+	}
+
+	e, ok := v.(*polochon.ShowEpisode)
+	if !ok {
+		s.renderError(w, &Error{
+			Code:    http.StatusInternalServerError,
+			Message: "invalid type",
+		})
+		return nil
+	}
+
+	return e
+}
+
+func (s *Server) getShowDetails(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	v, err := s.library.NewShowFromID(vars["id"])
+	if err != nil {
+		s.log.Error(err)
+		var status int
+		if err == index.ErrNotFound {
+			status = http.StatusNotFound
+		} else {
+			status = http.StatusInternalServerError
+		}
+		s.renderError(w, &Error{
+			Code:    status,
+			Message: "URL not found",
+		})
+		return
+	}
+
+	s.renderOK(w, v)
+}
+
+func (s *Server) getShowEpisodeIDDetails(w http.ResponseWriter, req *http.Request) {
+	e := s.getEpisode(w, req)
+	if e == nil {
+		return
+	}
+
+	s.renderOK(w, e)
+}
+
+func (s *Server) deleteEpisode(w http.ResponseWriter, req *http.Request) {
+	e := s.getEpisode(w, req)
+	if e == nil {
+		return
+	}
+
+	if err := s.library.Delete(e, s.log); err != nil {
+		s.renderError(w, &Error{
+			Code:    http.StatusInternalServerError,
+			Message: "URL not found",
+		})
+		return
+	}
+
+	s.renderOK(w, nil)
+}
+
+func (s *Server) serveShow(w http.ResponseWriter, r *http.Request) {
+	e := s.getEpisode(w, r)
+	if e == nil {
+		return
+	}
+
+	s.serveFile(w, r, e.GetFile())
+}

--- a/app/internal/token/config_test.go
+++ b/app/internal/token/config_test.go
@@ -32,7 +32,7 @@ var configFile = strings.NewReader(`
   include:
     - user
   allowed:
-    - DeleteByID
+    - DeleteEpisode
   token:
   - name: admin1
     value: admin1token
@@ -53,7 +53,7 @@ func createExpectedManager() *Manager {
 
 	rAdmin := &Role{
 		Name:    "admin",
-		Allowed: []string{"DeleteByID"},
+		Allowed: []string{"DeleteEpisode"},
 		Include: []*Role{rUser},
 	}
 

--- a/app/internal/token/config_test.go
+++ b/app/internal/token/config_test.go
@@ -12,7 +12,6 @@ var configFile = strings.NewReader(`
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   allownotoken: true
   token:
   - name: guest1
@@ -33,7 +32,7 @@ var configFile = strings.NewReader(`
   include:
     - user
   allowed:
-    - DeleteBySlugs
+    - DeleteByID
   token:
   - name: admin1
     value: admin1token
@@ -42,7 +41,7 @@ var configFile = strings.NewReader(`
 func createExpectedManager() *Manager {
 	rGuest := &Role{
 		Name:    "guest",
-		Allowed: []string{"TokenGetAllowed", "MoviesListIDs", "ShowsListSlugs"},
+		Allowed: []string{"TokenGetAllowed", "MoviesListIDs"},
 		Include: []*Role{},
 	}
 
@@ -54,7 +53,7 @@ func createExpectedManager() *Manager {
 
 	rAdmin := &Role{
 		Name:    "admin",
-		Allowed: []string{"DeleteBySlugs"},
+		Allowed: []string{"DeleteByID"},
 		Include: []*Role{rUser},
 	}
 
@@ -97,7 +96,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: guest2
     value: guest2token
@@ -105,7 +103,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: guest1
     value: guest1token
@@ -118,7 +115,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: guest1
     value: guest1token
@@ -133,7 +129,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: guest1
     value: guest1token
@@ -148,7 +143,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   include:
     - user
   token:
@@ -164,7 +158,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: guest2
     value: guest2token
@@ -173,7 +166,6 @@ var invalidMock = []struct {
   allowed:
     - TokenGetAllowed
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: guest1
     value: guest1token

--- a/app/internal/token/middleware_test.go
+++ b/app/internal/token/middleware_test.go
@@ -19,7 +19,7 @@ func createTestNegroni() *negroni.Negroni {
 	router := mux.NewRouter()
 	router.HandleFunc("/guest", fakeHandler).Name("TokenGetAllowed")
 	router.HandleFunc("/user", fakeHandler).Name("TorrentsAdd")
-	router.HandleFunc("/admin", fakeHandler).Name("DeleteByID")
+	router.HandleFunc("/admin", fakeHandler).Name("DeleteEpisode")
 	router.HandleFunc("/noname", fakeHandler)
 
 	tmiddleware := NewMiddleware(manager, router)

--- a/app/internal/token/middleware_test.go
+++ b/app/internal/token/middleware_test.go
@@ -19,7 +19,7 @@ func createTestNegroni() *negroni.Negroni {
 	router := mux.NewRouter()
 	router.HandleFunc("/guest", fakeHandler).Name("TokenGetAllowed")
 	router.HandleFunc("/user", fakeHandler).Name("TorrentsAdd")
-	router.HandleFunc("/admin", fakeHandler).Name("DeleteBySlugs")
+	router.HandleFunc("/admin", fakeHandler).Name("DeleteByID")
 	router.HandleFunc("/noname", fakeHandler)
 
 	tmiddleware := NewMiddleware(manager, router)
@@ -90,15 +90,15 @@ func TestMiddlewareAllow(t *testing.T) {
 	defer s.Close()
 
 	for _, tt := range testMock {
-		resp, err := http.Get(s.URL + tt.Path + "?token=" + tt.Value)
+		url := s.URL + tt.Path + "?token=" + tt.Value
+		resp, err := http.Get(url)
 		if err != nil {
 			t.Error(err)
 		}
 
 		if resp.StatusCode != tt.Expected {
-			t.Error("Expected:", tt.Expected, ", got:", resp.StatusCode)
+			t.Errorf("Expected: %d got %d for the URL %q", tt.Expected, resp.StatusCode, url)
 		}
-
 	}
 }
 

--- a/app/internal/token/token_test.go
+++ b/app/internal/token/token_test.go
@@ -13,7 +13,7 @@ func TestGetAllowed(t *testing.T) {
 	}{
 		{"guest1token", []string{"TokenGetAllowed", "MoviesListIDs"}},
 		{"user1token", []string{"TorrentsAdd", "TokenGetAllowed", "MoviesListIDs"}},
-		{"admin1token", []string{"DeleteByID", "TorrentsAdd", "TokenGetAllowed", "MoviesListIDs"}},
+		{"admin1token", []string{"DeleteEpisode", "TorrentsAdd", "TokenGetAllowed", "MoviesListIDs"}},
 	}
 
 	for _, tt := range testMock {

--- a/app/internal/token/token_test.go
+++ b/app/internal/token/token_test.go
@@ -11,9 +11,9 @@ func TestGetAllowed(t *testing.T) {
 		Value    string
 		Expected []string
 	}{
-		{"guest1token", []string{"TokenGetAllowed", "MoviesListIDs", "ShowsListSlugs"}},
-		{"user1token", []string{"TorrentsAdd", "TokenGetAllowed", "MoviesListIDs", "ShowsListSlugs"}},
-		{"admin1token", []string{"DeleteBySlugs", "TorrentsAdd", "TokenGetAllowed", "MoviesListIDs", "ShowsListSlugs"}},
+		{"guest1token", []string{"TokenGetAllowed", "MoviesListIDs"}},
+		{"user1token", []string{"TorrentsAdd", "TokenGetAllowed", "MoviesListIDs"}},
+		{"admin1token", []string{"DeleteByID", "TorrentsAdd", "TokenGetAllowed", "MoviesListIDs"}},
 	}
 
 	for _, tt := range testMock {
@@ -35,8 +35,6 @@ func TestIsAllowed(t *testing.T) {
 		{"guest1token", "TorrentsAdd", false},
 		{"user1token", "TokenGetAllowed", true},
 		{"user1token", "TorrentsAdd", true},
-		{"user1token", "DeleteBySlugs", false},
-		{"admin1token", "DeleteBySlugs", true},
 	}
 
 	for _, tt := range testMock {

--- a/lib/file.go
+++ b/lib/file.go
@@ -115,12 +115,12 @@ func (f *File) Guess(movieConf MovieConfig, showConf ShowConfig, log *logrus.Ent
 
 // NfoPath is an helper to get the nfo filename from the video filename
 func (f *File) NfoPath() string {
-	return f.filePathWithoutExt() + ".nfo"
+	return f.PathWithoutExt() + ".nfo"
 }
 
 // SubtitlePath is an helper to get the subtitle path from the  filename
 func (f *File) SubtitlePath() string {
-	return f.filePathWithoutExt() + ".srt"
+	return f.PathWithoutExt() + ".srt"
 }
 
 // IgnorePath is an helper to get the ignore file path
@@ -128,8 +128,8 @@ func (f *File) IgnorePath() string {
 	return f.Path + ".ignore"
 }
 
-// filePathWithoutExt returns the file path without the file extension
-func (f *File) filePathWithoutExt() string {
+// PathWithoutExt returns the file path without the file extension
+func (f *File) PathWithoutExt() string {
 	return RemoveExt(f.Path)
 }
 

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -14,7 +14,7 @@ func TestFilePathWithoutExt(t *testing.T) {
 		"file":          "file",
 	} {
 		file := NewFile(path)
-		got := file.filePathWithoutExt()
+		got := file.PathWithoutExt()
 
 		if got != expected {
 			t.Errorf("got %q, expected %q", got, expected)

--- a/lib/library/library.go
+++ b/lib/library/library.go
@@ -119,7 +119,7 @@ func (l *Library) HasMovie(imdbID string) (bool, error) {
 
 // HasShowEpisode returns true if the show is in the store
 func (l *Library) HasShowEpisode(imdbID string, season, episode int) (bool, error) {
-	return l.showIndex.Has(imdbID, season, episode)
+	return l.showIndex.HasEpisode(imdbID, season, episode)
 }
 
 // Add video
@@ -385,7 +385,7 @@ func (l *Library) DeleteShowEpisode(se *polochon.ShowEpisode, log *logrus.Entry)
 	}
 
 	// Remove the episode from the index
-	if err := l.showIndex.Remove(se, log); err != nil {
+	if err := l.showIndex.RemoveEpisode(se, log); err != nil {
 		return err
 	}
 
@@ -444,7 +444,7 @@ func (l *Library) ShowIds() (map[string]index.IndexedShow, error) {
 
 // SearchMovieByImdbID returns the video by its imdb ID
 func (l *Library) SearchMovieByImdbID(imdbID string) (polochon.Video, error) {
-	path, err := l.movieIndex.SearchByImdbID(imdbID)
+	path, err := l.movieIndex.MoviePath(imdbID)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/library/library.go
+++ b/lib/library/library.go
@@ -401,7 +401,8 @@ func (l *Library) DeleteShowEpisode(se *polochon.ShowEpisode, log *logrus.Entry)
 			return err
 		}
 		// Remove the season from the index
-		if err := l.showIndex.RemoveSeason(se.Show, se.Season, log); err != nil {
+		show := &polochon.Show{ImdbID: se.ShowImdbID}
+		if err := l.showIndex.RemoveSeason(show, se.Season, log); err != nil {
 			return err
 		}
 	}
@@ -418,7 +419,8 @@ func (l *Library) DeleteShowEpisode(se *polochon.ShowEpisode, log *logrus.Entry)
 			return err
 		}
 		// Remove the show from the index
-		if err := l.showIndex.RemoveShow(se.Show, log); err != nil {
+		show := &polochon.Show{ImdbID: se.ShowImdbID}
+		if err := l.showIndex.RemoveShow(show, log); err != nil {
 			return err
 		}
 	}

--- a/lib/library/library_test.go
+++ b/lib/library/library_test.go
@@ -1,15 +1,19 @@
-package polochon
+package library
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/odwrtw/polochon/lib"
 )
 
+var mockLogEntry = logrus.NewEntry(&logrus.Logger{Out: ioutil.Discard})
+
 func TestStoreMovieNoPath(t *testing.T) {
-	vs := NewVideoStore(FileConfig{}, MovieConfig{}, ShowConfig{}, VideoStoreConfig{})
-	movie := mockMovie(MovieConfig{})
+	vs := NewVideoStore(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, VideoStoreConfig{})
+	movie := &polochon.Movie{}
 
 	if err := vs.Add(movie, mockLogEntry); err != ErrMissingMovieFilePath {
 		t.Errorf("Expected %q, got %q", ErrMissingMovieFilePath, err)
@@ -36,7 +40,7 @@ func TestStoreMovie(t *testing.T) {
 		return nil
 	}
 
-	vs := NewVideoStore(FileConfig{}, MovieConfig{}, ShowConfig{}, VideoStoreConfig{
+	vs := NewVideoStore(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, VideoStoreConfig{
 		MovieDir: "/movie",
 		ShowDir:  "/show",
 	})
@@ -45,10 +49,10 @@ func TestStoreMovie(t *testing.T) {
 		return nil
 	}
 
-	movie := &Movie{
+	movie := &polochon.Movie{
 		Title: "Test Movie",
 		Year:  1,
-		File: File{
+		File: polochon.File{
 			Path: "/testmovie.avi",
 		},
 		Fanart: "/",
@@ -67,7 +71,7 @@ func TestStoreMovie(t *testing.T) {
 }
 
 type FakeShowDetailer struct {
-	show Show
+	show polochon.Show
 }
 
 func (d *FakeShowDetailer) Name() string {
@@ -76,14 +80,14 @@ func (d *FakeShowDetailer) Name() string {
 
 func (d *FakeShowDetailer) GetDetails(i interface{}, log *logrus.Entry) error {
 	switch v := i.(type) {
-	case *Show:
+	case *polochon.Show:
 		return d.showDetails(v)
 	default:
 		return fmt.Errorf("Error invalid type")
 	}
 }
 
-func (d *FakeShowDetailer) showDetails(s *Show) error {
+func (d *FakeShowDetailer) showDetails(s *polochon.Show) error {
 	s.Title = d.show.Title
 	s.Plot = d.show.Plot
 	s.TvdbID = d.show.TvdbID
@@ -116,7 +120,7 @@ func TestStoreShow(t *testing.T) {
 	}
 
 	showDetailer := &FakeShowDetailer{
-		show: Show{
+		show: polochon.Show{
 			Title:  "Test show",
 			Plot:   "Test show plot",
 			TvdbID: 0,
@@ -128,7 +132,7 @@ func TestStoreShow(t *testing.T) {
 		},
 	}
 
-	vs := NewVideoStore(FileConfig{}, MovieConfig{}, ShowConfig{}, VideoStoreConfig{
+	vs := NewVideoStore(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, VideoStoreConfig{
 		MovieDir: "/movie",
 		ShowDir:  "/show",
 	})
@@ -137,15 +141,15 @@ func TestStoreShow(t *testing.T) {
 		return nil
 	}
 
-	episode := &ShowEpisode{
+	episode := &polochon.ShowEpisode{
 		Title:     "Test Episode",
 		ShowTitle: "Test show",
 		Season:    1,
-		File: File{
+		File: polochon.File{
 			Path: "/episode.avi",
 		},
-		ShowConfig: ShowConfig{
-			Detailers: []Detailer{showDetailer},
+		ShowConfig: polochon.ShowConfig{
+			Detailers: []polochon.Detailer{showDetailer},
 		},
 	}
 

--- a/lib/library/library_test.go
+++ b/lib/library/library_test.go
@@ -12,10 +12,10 @@ import (
 var mockLogEntry = logrus.NewEntry(&logrus.Logger{Out: ioutil.Discard})
 
 func TestStoreMovieNoPath(t *testing.T) {
-	vs := NewVideoStore(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, VideoStoreConfig{})
+	library := New(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, Config{})
 	movie := &polochon.Movie{}
 
-	if err := vs.Add(movie, mockLogEntry); err != ErrMissingMovieFilePath {
+	if err := library.Add(movie, mockLogEntry); err != ErrMissingMovieFilePath {
 		t.Errorf("Expected %q, got %q", ErrMissingMovieFilePath, err)
 	}
 }
@@ -40,12 +40,12 @@ func TestStoreMovie(t *testing.T) {
 		return nil
 	}
 
-	vs := NewVideoStore(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, VideoStoreConfig{
+	library := New(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, Config{
 		MovieDir: "/movie",
 		ShowDir:  "/show",
 	})
 
-	writeNFOFile = func(filePath string, i interface{}, vs *VideoStore) error {
+	writeNFOFile = func(filePath string, i interface{}, library *Library) error {
 		return nil
 	}
 
@@ -61,7 +61,7 @@ func TestStoreMovie(t *testing.T) {
 
 	expectedNewPath := "/movie/Test Movie (1)/testmovie.avi"
 
-	if err := vs.Add(movie, mockLogEntry); err != nil {
+	if err := library.Add(movie, mockLogEntry); err != nil {
 		t.Errorf("Expected nil, got %q", err)
 	}
 
@@ -124,7 +124,7 @@ func TestStoreShow(t *testing.T) {
 			Title:  "Test show",
 			Plot:   "Test show plot",
 			TvdbID: 0,
-			URL:    "http://fakeurl.test",
+			URL:    "http://fakeurlibrary.test",
 			ImdbID: "ttFakeShow",
 			Banner: "/",
 			Fanart: "/",
@@ -132,12 +132,12 @@ func TestStoreShow(t *testing.T) {
 		},
 	}
 
-	vs := NewVideoStore(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, VideoStoreConfig{
+	library := New(polochon.FileConfig{}, polochon.MovieConfig{}, polochon.ShowConfig{}, Config{
 		MovieDir: "/movie",
 		ShowDir:  "/show",
 	})
 
-	writeNFOFile = func(filePath string, i interface{}, vs *VideoStore) error {
+	writeNFOFile = func(filePath string, i interface{}, library *Library) error {
 		return nil
 	}
 
@@ -155,7 +155,7 @@ func TestStoreShow(t *testing.T) {
 
 	expectedNewPath := "/show/Test show/Season 1/episode.avi"
 
-	if err := vs.Add(episode, mockLogEntry); err != nil {
+	if err := library.Add(episode, mockLogEntry); err != nil {
 		t.Errorf("Expected nil, got %q", err)
 	}
 

--- a/lib/media_index/errors.go
+++ b/lib/media_index/errors.go
@@ -1,0 +1,8 @@
+package index
+
+import "errors"
+
+// Custom errors
+var (
+	ErrNotFound = errors.New("index: not found")
+)

--- a/lib/media_index/movie_index.go
+++ b/lib/media_index/movie_index.go
@@ -1,9 +1,10 @@
-package polochon
+package index
 
 import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/odwrtw/polochon/lib"
 )
 
 // MovieIndex is an index for the movies
@@ -46,14 +47,14 @@ func (mi *MovieIndex) SearchByImdbID(imdbID string) (string, error) {
 func (mi *MovieIndex) searchMovieByImdbID(imdbID string) (string, error) {
 	filePath, ok := mi.ids[imdbID]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	return filePath, nil
 }
 
 // Add adds a movie to an index
-func (mi *MovieIndex) Add(movie *Movie) error {
+func (mi *MovieIndex) Add(movie *polochon.Movie) error {
 	mi.Lock()
 	defer mi.Unlock()
 
@@ -63,13 +64,13 @@ func (mi *MovieIndex) Add(movie *Movie) error {
 }
 
 // Remove will delete the movie from the index
-func (mi *MovieIndex) Remove(m *Movie, log *logrus.Entry) error {
+func (mi *MovieIndex) Remove(m *polochon.Movie, log *logrus.Entry) error {
 	mi.Lock()
 	defer mi.Unlock()
 
 	if _, ok := mi.ids[m.ImdbID]; !ok {
 		log.Errorf("Movie not in ids index, WEIRD")
-		return ErrImdbIDNotFound
+		return ErrNotFound
 	}
 	delete(mi.ids, m.ImdbID)
 

--- a/lib/media_index/movie_index_test.go
+++ b/lib/media_index/movie_index_test.go
@@ -1,8 +1,10 @@
-package polochon
+package index
 
 import (
 	"log"
 	"testing"
+
+	"github.com/odwrtw/polochon/lib"
 )
 
 // NewMovieIndex returns a new movie index
@@ -58,7 +60,7 @@ func TestSearchMovieByImdbID(t *testing.T) {
 		},
 		"tt1234": {
 			"",
-			ErrImdbIDNotFound,
+			ErrNotFound,
 		},
 	} {
 		res, err := m.searchMovieByImdbID(i)
@@ -74,7 +76,7 @@ func TestSearchMovieByImdbID(t *testing.T) {
 func TestAddAndRemoveMovieToIndex(t *testing.T) {
 	mi := mockMovieIndex()
 
-	m := mockMovie(MovieConfig{})
+	m := &polochon.Movie{ImdbID: "tt2562232"}
 	m.Path = "/home/test/movie/movie.mp4"
 	err := mi.Add(m)
 	if err != nil {

--- a/lib/media_index/show_index.go
+++ b/lib/media_index/show_index.go
@@ -1,10 +1,11 @@
-package polochon
+package index
 
 import (
 	"path/filepath"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/odwrtw/polochon/lib"
 )
 
 // ShowIndex is an index for the shows
@@ -81,17 +82,17 @@ func (si *ShowIndex) EpisodePath(imdbID string, sNum, eNum int) (string, error) 
 
 	show, ok := si.shows[imdbID]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	season, ok := show.Seasons[sNum]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	filePath, ok := season.Episodes[eNum]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	return filePath, nil
@@ -104,12 +105,12 @@ func (si *ShowIndex) SeasonPath(imdbID string, sNum int) (string, error) {
 
 	show, ok := si.shows[imdbID]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	season, ok := show.Seasons[sNum]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	return season.Path, nil
@@ -122,14 +123,14 @@ func (si *ShowIndex) ShowPath(imdbID string) (string, error) {
 
 	show, ok := si.shows[imdbID]
 	if !ok {
-		return "", ErrImdbIDNotFound
+		return "", ErrNotFound
 	}
 
 	return show.Path, nil
 }
 
 // Add adds a show episode to the index
-func (si *ShowIndex) Add(episode *ShowEpisode) error {
+func (si *ShowIndex) Add(episode *polochon.ShowEpisode) error {
 	si.Lock()
 	defer si.Unlock()
 
@@ -201,7 +202,7 @@ func (si *ShowIndex) IsSeasonEmpty(imdbID string, season int) (bool, error) {
 }
 
 // RemoveSeason removes the season from the index
-func (si *ShowIndex) RemoveSeason(show *Show, season int, log *logrus.Entry) error {
+func (si *ShowIndex) RemoveSeason(show *polochon.Show, season int, log *logrus.Entry) error {
 	log.Infof("Deleting whole season %d of %s from index", season, show.ImdbID)
 
 	delete(si.shows[show.ImdbID].Seasons, season)
@@ -210,7 +211,7 @@ func (si *ShowIndex) RemoveSeason(show *Show, season int, log *logrus.Entry) err
 }
 
 // RemoveShow removes the show from the index
-func (si *ShowIndex) RemoveShow(show *Show, log *logrus.Entry) error {
+func (si *ShowIndex) RemoveShow(show *polochon.Show, log *logrus.Entry) error {
 	log.Infof("Deleting whole show %s from index", show.ImdbID)
 
 	for _, ep := range show.Episodes {
@@ -224,7 +225,7 @@ func (si *ShowIndex) RemoveShow(show *Show, log *logrus.Entry) error {
 }
 
 // Remove removes the show episode from the index
-func (si *ShowIndex) Remove(episode *ShowEpisode, log *logrus.Entry) error {
+func (si *ShowIndex) Remove(episode *polochon.ShowEpisode, log *logrus.Entry) error {
 	si.Lock()
 	defer si.Unlock()
 

--- a/lib/media_index/show_index_test.go
+++ b/lib/media_index/show_index_test.go
@@ -1,9 +1,15 @@
-package polochon
+package index
 
 import (
+	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/odwrtw/polochon/lib"
 )
+
+var mockLogEntry = logrus.NewEntry(&logrus.Logger{Out: ioutil.Discard})
 
 func mockShowIndex() ShowIndex {
 	return ShowIndex{
@@ -146,7 +152,7 @@ func TestRemoveSeason(t *testing.T) {
 		t.Fatal("season should not be empty")
 	}
 
-	s := &Show{ImdbID: id}
+	s := &polochon.Show{ImdbID: id}
 	if err := idx.RemoveSeason(s, season, mockLogEntry); err != nil {
 		t.Fatalf("error while removing season from the index: %q", err)
 	}
@@ -172,7 +178,7 @@ func TestRemoveShow(t *testing.T) {
 		t.Fatal("show should not be empty")
 	}
 
-	s := &Show{ImdbID: id}
+	s := &polochon.Show{ImdbID: id}
 	if err := idx.RemoveShow(s, mockLogEntry); err != nil {
 		t.Fatalf("error while removing show from the index: %q", err)
 	}
@@ -193,10 +199,11 @@ func TestAddEpisodeToIndex(t *testing.T) {
 	expectedSeasonPath := filepath.Join(expectedShowPath, "Season 1")
 
 	// Create a fake show and a fake show episode
-	e := mockShowEpisode()
-	s := mockShow()
-	s.ImdbID = e.ShowImdbID
-	e.Show = s
+	e := &polochon.ShowEpisode{
+		ShowImdbID: "tt0397306",
+		Season:     1,
+		Episode:    1,
+	}
 	e.Path = filepath.Join(expectedSeasonPath, "My show 1 - s01e01.mp4")
 
 	// Add it to the index

--- a/lib/media_index/tools.go
+++ b/lib/media_index/tools.go
@@ -1,4 +1,4 @@
-package polochon
+package index
 
 // tool to extract the keys of the map
 func extractMapKeys(input map[string]string) ([]string, error) {

--- a/lib/media_index/tools.go
+++ b/lib/media_index/tools.go
@@ -1,7 +1,9 @@
 package index
 
+import "sort"
+
 // tool to extract the keys of the map
-func extractMapKeys(input map[string]string) ([]string, error) {
+func extractAndSortMapKeys(input map[string]string) ([]string, error) {
 	// Prepare the return slice
 	ret := make([]string, len(input))
 
@@ -10,6 +12,9 @@ func extractMapKeys(input map[string]string) ([]string, error) {
 		ret[i] = k
 		i++
 	}
+
+	// Sort the result for a deterministic result
+	sort.Strings(ret)
 
 	return ret, nil
 }

--- a/lib/movie.go
+++ b/lib/movie.go
@@ -1,8 +1,6 @@
 package polochon
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 
@@ -35,18 +33,6 @@ type Movie struct {
 	Votes         int       `json:"votes"`
 	Year          int       `json:"year"`
 	Torrents      []Torrent `json:"torrents"`
-}
-
-// MarshalJSON is a custom marshal function to handle public path
-func (m *Movie) MarshalJSON() ([]byte, error) {
-	var aux struct {
-		Movie
-		Slug string `json:"slug"`
-	}
-	aux.Slug = m.Slug()
-	aux.Movie = *m
-
-	return json.Marshal(aux)
 }
 
 // NewMovie returns a new movie
@@ -161,9 +147,4 @@ func (m *Movie) GetSubtitle(log *logrus.Entry) error {
 		return c
 	}
 	return nil
-}
-
-// Slug will slug the movie name
-func (m *Movie) Slug() string {
-	return slug(fmt.Sprintf("%s", m.Title))
 }

--- a/lib/movie_test.go
+++ b/lib/movie_test.go
@@ -71,13 +71,3 @@ func TestMovieNFOReader(t *testing.T) {
 		t.Errorf("Failed to deserialize movie NFO")
 	}
 }
-
-func TestMovieSlug(t *testing.T) {
-	s := mockMovie(MovieConfig{})
-	got := s.Slug()
-	expected := "birdman"
-
-	if got != expected {
-		t.Errorf("got %q, expected %q", got, expected)
-	}
-}

--- a/lib/movieindex_test.go
+++ b/lib/movieindex_test.go
@@ -8,19 +8,13 @@ import (
 // NewMovieIndex returns a new movie index
 func mockMovieIndex() *MovieIndex {
 	return &MovieIndex{
-		ids:   map[string]string{},
-		slugs: map[string]string{},
+		ids: map[string]string{},
 	}
 }
 
 var idsIndex = map[string]string{
 	"tt56789": "/home/test/movie/movie.mp4",
 	"tt12345": "/home/test/movieBis/movieBis.mp4",
-}
-
-var slugsIndex = map[string]string{
-	"movie":    "/home/test/movie/movie.mp4",
-	"movieBis": "/home/test/movieBis/movieBis.mp4",
 }
 
 func TestHasMovie(t *testing.T) {
@@ -39,40 +33,6 @@ func TestHasMovie(t *testing.T) {
 		}
 		if expected != res {
 			t.Errorf("TestHasMovie: expected %t, got %t for %s", expected, res, i)
-		}
-	}
-}
-
-func TestSearchMovieBySlug(t *testing.T) {
-	m := mockMovieIndex()
-
-	m.slugs = slugsIndex
-
-	type res struct {
-		path string
-		err  error
-	}
-
-	for s, expected := range map[string]res{
-		"movie": {
-			"/home/test/movie/movie.mp4",
-			nil,
-		},
-		"movieBis": {
-			"/home/test/movieBis/movieBis.mp4",
-			nil,
-		},
-		"movieDoubleBis": {
-			"",
-			ErrSlugNotFound,
-		},
-	} {
-		res, err := m.searchMovieBySlug(s)
-		if expected.path != res {
-			t.Errorf("TestSearchBySlug: expected %s, got %s for %s", expected.path, res, s)
-		}
-		if expected.err != err {
-			t.Errorf("TestSearchBySlug: expected error %s, got %s for %s", expected.err, err, s)
 		}
 	}
 }
@@ -141,28 +101,6 @@ func TestAddAndRemoveMovieToIndex(t *testing.T) {
 	}
 	if res != false {
 		t.Errorf("Should not have the movie %s in index", m.ImdbID)
-	}
-}
-
-func TestMovieSlugs(t *testing.T) {
-	m := mockMovieIndex()
-
-	m.slugs = slugsIndex
-
-	expectedSlugs := []string{"movie", "movieBis"}
-	slugs, err := m.Slugs()
-	if err != nil {
-		t.Fatal(err)
-	}
-LOOP:
-	for _, exp := range expectedSlugs {
-		for _, s := range slugs {
-			// if we found the element, go to the next one
-			if exp == s {
-				continue LOOP
-			}
-		}
-		t.Errorf("TestIDs: %s is not in the result", exp)
 	}
 }
 

--- a/lib/show.go
+++ b/lib/show.go
@@ -18,10 +18,10 @@ type Show struct {
 	ImdbID     string         `json:"imdb_id"`
 	Year       int            `json:"year"`
 	FirstAired *time.Time     `json:"first_aired"`
-	Banner     string         `json:"banner"`
-	Fanart     string         `json:"fanart"`
-	Poster     string         `json:"poster"`
-	Episodes   []*ShowEpisode `json:"episodes"`
+	Banner     string         `json:"-"`
+	Fanart     string         `json:"-"`
+	Poster     string         `json:"-"`
+	Episodes   []*ShowEpisode `json:"-"`
 }
 
 // NewShow returns a new show

--- a/lib/showepisode.go
+++ b/lib/showepisode.go
@@ -1,8 +1,6 @@
 package polochon
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 
@@ -38,18 +36,6 @@ type ShowEpisode struct {
 	ReleaseGroup  string    `json:"release_group"`
 	Torrents      []Torrent `json:"torrents"`
 	Show          *Show     `json:"-"`
-}
-
-// MarshalJSON is a custom marshal function to handle public path
-func (s *ShowEpisode) MarshalJSON() ([]byte, error) {
-	var aux struct {
-		ShowEpisode
-		Slug string `json:"slug"`
-	}
-	aux.Slug = s.Slug()
-	aux.ShowEpisode = *s
-
-	return json.Marshal(aux)
 }
 
 // NewShowEpisode returns a new show episode
@@ -165,9 +151,4 @@ func (s *ShowEpisode) GetSubtitle(log *logrus.Entry) error {
 		return c
 	}
 	return nil
-}
-
-// Slug will slug the show episode
-func (s *ShowEpisode) Slug() string {
-	return slug(fmt.Sprintf("%s-s%02de%02d", s.ShowTitle, s.Season, s.Episode))
 }

--- a/lib/showepisode_test.go
+++ b/lib/showepisode_test.go
@@ -66,13 +66,3 @@ func TestShowEpisodeReader(t *testing.T) {
 		t.Errorf("Failed to deserialize show episode NFO.\nGot: %#v\nExpected: %#v", got, expected)
 	}
 }
-
-func TestShowEpisodeSlug(t *testing.T) {
-	s := mockShowEpisode()
-	got := s.Slug()
-	expected := "american-dad-s09e18"
-
-	if got != expected {
-		t.Errorf("got %q, expected %q", got, expected)
-	}
-}

--- a/lib/showindex_test.go
+++ b/lib/showindex_test.go
@@ -8,8 +8,7 @@ import (
 // NewMovieIndex returns a new movie index
 func newFakeShowIndex() *ShowIndex {
 	return &ShowIndex{
-		ids:   map[string]map[int]map[int]string{},
-		slugs: map[string]string{},
+		ids: map[string]map[int]map[int]string{},
 	}
 }
 
@@ -39,14 +38,6 @@ var showIdsIndex = map[string]map[int]map[int]string{
 	},
 }
 
-var showSlugsIndex = map[string]string{
-	"show-s01e01":         "/home/test/show/season-1/show-s01e01.mp4",
-	"show-s01e02":         "/home/test/show/season-1/show-s01e02.mp4",
-	"show-s02e02":         "/home/test/show/season-2/show-s02e02.mp4",
-	"showBis-s02e01":      "/home/test/showBis/season-2/showBis-s01e01.mp4",
-	"american-dad-s09e18": "/home/test/show/season-1/showTers-s09e18.mp4",
-}
-
 func TestHasShowEpisode(t *testing.T) {
 	s := newFakeShowIndex()
 
@@ -71,48 +62,6 @@ func TestHasShowEpisode(t *testing.T) {
 		}
 		if expected != res {
 			t.Errorf("TestHasMovie: expected %t, got %t for %s s%d e%d", expected, res, h.imdbID, h.season, h.episode)
-		}
-	}
-}
-
-func TestSearchShowBySlug(t *testing.T) {
-	si := newFakeShowIndex()
-
-	si.slugs = showSlugsIndex
-
-	type res struct {
-		path string
-		err  error
-	}
-
-	for s, expected := range map[string]res{
-		"show-s01e01": {
-			"/home/test/show/season-1/show-s01e01.mp4",
-			nil,
-		},
-		"show-s02e02": {
-			"/home/test/show/season-2/show-s02e02.mp4",
-			nil,
-		},
-		"showBis-s02e01": {
-			"/home/test/showBis/season-2/showBis-s01e01.mp4",
-			nil,
-		},
-		"showBisBis-s02e01": {
-			"",
-			ErrSlugNotFound,
-		},
-		"show-s01e03": {
-			"",
-			ErrSlugNotFound,
-		},
-	} {
-		res, err := si.searchShowEpisodeBySlug(s)
-		if expected.path != res {
-			t.Errorf("TestSearchBySlug: expected %s, got %s for %s", expected.path, res, s)
-		}
-		if expected.err != err {
-			t.Errorf("TestSearchBySlug: expected error %s, got %s for %s", expected.err, err, s)
 		}
 	}
 }
@@ -168,7 +117,6 @@ func TestRemoveSeason(t *testing.T) {
 	si := newFakeShowIndex()
 
 	si.ids = showIdsIndex
-	si.slugs = showSlugsIndex
 
 	res, err := si.IsSeasonEmpty("tt0397306", 9)
 	if err != nil {
@@ -265,34 +213,6 @@ func TestAddAndDeleteEpisodeToIndex(t *testing.T) {
 	}
 	if res != false {
 		t.Errorf("Should not have the episode %+v in index", e)
-	}
-}
-
-func TestShowSlugs(t *testing.T) {
-	si := newFakeShowIndex()
-
-	si.slugs = showSlugsIndex
-
-	expectedSlugs := []string{
-		"show-s01e01",
-		"show-s01e02",
-		"show-s02e02",
-		"showBis-s02e01",
-	}
-
-	slugs, err := si.Slugs()
-	if err != nil {
-		t.Fatal(err)
-	}
-LOOP:
-	for _, exp := range expectedSlugs {
-		for _, s := range slugs {
-			// if we found the element, go to the next one
-			if exp == s {
-				continue LOOP
-			}
-		}
-		t.Errorf("TestIDs: %s is not in the result", exp)
 	}
 }
 

--- a/lib/showindex_test.go
+++ b/lib/showindex_test.go
@@ -1,232 +1,232 @@
 package polochon
 
 import (
-	"reflect"
+	"path/filepath"
 	"testing"
 )
 
-// NewMovieIndex returns a new movie index
-func newFakeShowIndex() *ShowIndex {
-	return &ShowIndex{
-		ids: map[string]map[int]map[int]string{},
-	}
-}
+func mockShowIndex() ShowIndex {
+	return ShowIndex{
+		shows: map[string]IndexedShow{
+			"tt56789": {
+				Path: "/home/test/tt56789",
+				Seasons: map[int]IndexedSeason{
+					1: {
+						Path: "/home/test/tt56789/1",
+						Episodes: map[int]string{
+							1: "/home/test/tt56789/1/s01e01.mp4",
+							2: "/home/test/tt56789/1/s01e02.mp4",
+						},
+					},
+					2: {
+						Path: "/home/test/tt56789/2",
+						Episodes: map[int]string{
+							2: "/home/test/tt56789/2/s02e02.mp4",
+						},
+					},
+				},
+			},
 
-var showIdsIndex = map[string]map[int]map[int]string{
-	"tt56789": {
-		1: {
-			1: "/home/test/show/season-1/show-s01e01.mp4",
-			2: "/home/test/show/season-1/show-s01e02.mp4",
+			"tt12345": {
+				Path: "/home/test/tt12345",
+				Seasons: map[int]IndexedSeason{
+					2: {
+						Path: "/home/test/tt12345/2",
+						Episodes: map[int]string{
+							1: "/home/test/tt12345/2/s02e01.mp4",
+						},
+					},
+				},
+			},
+
+			"tt0397306": {
+				Path: "/home/test/tt0397306",
+				Seasons: map[int]IndexedSeason{
+					9: {
+						Path: "/home/test/tt0397306/9",
+						Episodes: map[int]string{
+							18: "/home/test/tt0397306/18/s09e18.mp4",
+						},
+					},
+				},
+			},
+
+			"tt123456": {},
+
+			"tt22222": {
+				Path: "/home/test/tt0397306",
+				Seasons: map[int]IndexedSeason{
+					2: {},
+				},
+			},
 		},
-		2: {
-			2: "/home/test/show/season-2/show-s02e02.mp4",
-		},
-	},
-	"tt12345": {
-		2: {
-			1: "/home/test/showBis/season-2/show-s02e01.mp4",
-		},
-	},
-	"tt123456": {},
-	"tt22222": {
-		2: {},
-	},
-	"tt0397306": {
-		9: {
-			18: "/home/test/show/season-1/showTers-s09e18.mp4",
-		},
-	},
+	}
 }
 
 func TestHasShowEpisode(t *testing.T) {
-	s := newFakeShowIndex()
+	idx := mockShowIndex()
 
-	s.ids = showIdsIndex
-
-	type has struct {
-		imdbID  string
-		season  int
-		episode int
-	}
-	for h, expected := range map[has]bool{
-		has{"tt56789", 1, 1}: true,
-		has{"tt56789", 1, 2}: true,
-		has{"tt56789", 1, 3}: false,
-		has{"tt12345", 1, 3}: false,
-		has{"tt12345", 2, 1}: true,
-		has{"tt11111", 2, 1}: false,
+	for _, mock := range []struct {
+		imdbID   string
+		season   int
+		episode  int
+		expected bool
+	}{
+		{"tt56789", 1, 1, true},
+		{"tt56789", 1, 2, true},
+		{"tt56789", 1, 3, false},
+		{"tt12345", 1, 3, false},
+		{"tt12345", 2, 1, true},
+		{"tt11111", 2, 1, false},
 	} {
-		res, err := s.Has(h.imdbID, h.season, h.episode)
+		got, err := idx.Has(mock.imdbID, mock.season, mock.episode)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to get episode from index: %q", err)
 		}
-		if expected != res {
-			t.Errorf("TestHasMovie: expected %t, got %t for %s s%d e%d", expected, res, h.imdbID, h.season, h.episode)
+
+		if mock.expected != got {
+			t.Errorf("expected %t, got %t for %s s%d e%d", mock.expected, got, mock.imdbID, mock.season, mock.episode)
 		}
 	}
 }
 
 func TestIsShowEmpty(t *testing.T) {
-	si := newFakeShowIndex()
-
-	si.ids = showIdsIndex
-	for s, expected := range map[string]bool{
+	idx := mockShowIndex()
+	for id, expected := range map[string]bool{
 		"tt456789": true,
 		"tt123456": true,
 		"tt56789":  false,
 		"tt12345":  false,
 	} {
-		res, err := si.IsShowEmpty(s)
+		got, err := idx.IsShowEmpty(id)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to check if the show is empty: %q", err)
 		}
-		if expected != res {
-			t.Errorf("TestIsShowEmpty: expected %t, got %t for %s", expected, res, s)
+		if expected != got {
+			t.Errorf("expected %t, got %t for %s", expected, got, id)
 		}
 	}
 }
 
 func TestIsSeasonEmpty(t *testing.T) {
-	si := newFakeShowIndex()
-
-	si.ids = showIdsIndex
-
-	type test struct {
-		imdbID string
-		season int
-	}
-	for s, expected := range map[test]bool{
-		test{"tt12345", 2}: false,
-		test{"tt12345", 3}: true,
-		test{"tt22222", 2}: true,
-		test{"tt22222", 1}: true,
-		test{"tt56789", 1}: false,
-		test{"tt56789", 2}: false,
+	idx := mockShowIndex()
+	for _, mock := range []struct {
+		imdbID   string
+		season   int
+		expected bool
+	}{
+		{"tt12345", 2, false},
+		{"tt12345", 3, true},
+		{"tt22222", 2, true},
+		{"tt22222", 1, true},
+		{"tt56789", 1, false},
+		{"tt56789", 2, false},
 	} {
-		res, err := si.IsSeasonEmpty(s.imdbID, s.season)
+		got, err := idx.IsSeasonEmpty(mock.imdbID, mock.season)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to check if the show season is empty: %q", err)
 		}
-		if expected != res {
-			t.Errorf("TestIsShowEmpty: expected %t, got %t for %s and %d", expected, res, s.imdbID, s.season)
+		if mock.expected != got {
+			t.Errorf("expected %t, got %t for %s and %d", mock.expected, got, mock.imdbID, mock.season)
 		}
 	}
 }
 
 func TestRemoveSeason(t *testing.T) {
-	si := newFakeShowIndex()
+	idx := mockShowIndex()
 
-	si.ids = showIdsIndex
+	id := "tt0397306"
+	season := 9
 
-	res, err := si.IsSeasonEmpty("tt0397306", 9)
+	empty, err := idx.IsSeasonEmpty(id, season)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
 	}
-	if res != false {
-		t.Fatalf("TestRemoveSeason: expected %t, got %t", false, res)
+	if empty {
+		t.Fatal("season should not be empty")
 	}
 
-	// Create a fake show and a fake show episode
-	e := mockShowEpisode()
-	s := mockShow()
-	s.Episodes = append(s.Episodes, e)
-	s.ImdbID = e.ShowImdbID
-	e.Path = "/home/test/show/season-1/showTers-s09e18.mp4"
+	s := &Show{ImdbID: id}
+	if err := idx.RemoveSeason(s, season, mockLogEntry); err != nil {
+		t.Fatalf("error while removing season from the index: %q", err)
+	}
 
-	si.RemoveSeason(s, 9, mockLogEntry)
-
-	res, err = si.IsSeasonEmpty("tt0397306", 9)
+	empty, err = idx.IsSeasonEmpty(id, season)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
 	}
-	if res != true {
-		t.Errorf("TestRemoveSeason: expected %t, got %t", true, res)
+	if !empty {
+		t.Fatal("season should be empty")
 	}
 }
 
 func TestRemoveShow(t *testing.T) {
-	si := newFakeShowIndex()
+	idx := mockShowIndex()
+	id := "tt0397306"
 
-	si.ids = showIdsIndex
-
-	res, err := si.IsShowEmpty("tt0397306")
+	empty, err := idx.IsShowEmpty(id)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
 	}
-	if res != false {
-		t.Fatalf("TestRemoveShow: expected %t, got %t", false, res)
+	if empty {
+		t.Fatal("show should not be empty")
 	}
 
-	// Create a fake show and a fake show episode
-	e := mockShowEpisode()
-	s := mockShow()
-	s.ImdbID = e.ShowImdbID
-	e.Show = s
-	e.Path = "/home/test/show/season-1/showTers-s09e18.mp4"
+	s := &Show{ImdbID: id}
+	if err := idx.RemoveShow(s, mockLogEntry); err != nil {
+		t.Fatalf("error while removing show from the index: %q", err)
+	}
 
-	si.RemoveShow(s, mockLogEntry)
-
-	res, err = si.IsShowEmpty("tt0397306")
+	empty, err = idx.IsShowEmpty(id)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
 	}
-	if res != true {
-		t.Errorf("TestRemoveShow: expected %t, got %t", true, res)
+	if !empty {
+		t.Fatal("show should be empty")
 	}
 }
 
-func TestAddAndDeleteEpisodeToIndex(t *testing.T) {
-	si := newFakeShowIndex()
+func TestAddEpisodeToIndex(t *testing.T) {
+	idx := NewShowIndex()
+
+	expectedShowPath := "/home/shows/My show 1"
+	expectedSeasonPath := filepath.Join(expectedShowPath, "Season 1")
 
 	// Create a fake show and a fake show episode
 	e := mockShowEpisode()
 	s := mockShow()
 	s.ImdbID = e.ShowImdbID
 	e.Show = s
-	e.Path = "/home/test/show/season-1/showTers-s09e18.mp4"
+	e.Path = filepath.Join(expectedSeasonPath, "My show 1 - s01e01.mp4")
 
 	// Add it to the index
-	err := si.Add(e)
-	if err != nil {
-		t.Fatal(err)
+	if err := idx.Add(e); err != nil {
+		t.Fatalf("error while adding show in the index: %q", err)
 	}
 
 	// Check
-	res, err := si.Has(e.ShowImdbID, e.Season, e.Episode)
+	hasEpisode, err := idx.Has(e.ShowImdbID, e.Season, e.Episode)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
 	}
-	if res != true {
-		t.Errorf("Should have the episode %+v in index", e)
+	if !hasEpisode {
+		t.Fatal("the index should have the episode")
 	}
 
-	// Remove it
-	err = si.Remove(e, mockLogEntry)
+	// Ensures the paths are correct
+	showPath, err := idx.ShowPath(e.ShowImdbID)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
+	}
+	if showPath != expectedShowPath {
+		t.Errorf("expected show path to be %q, got %q", expectedShowPath, showPath)
 	}
 
-	// Check
-	res, err = si.Has(e.ShowImdbID, e.Season, e.Episode)
+	seasonPath, err := idx.SeasonPath(e.ShowImdbID, e.Season)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("expected no error, got %q", err)
 	}
-	if res != false {
-		t.Errorf("Should not have the episode %+v in index", e)
-	}
-}
-
-func TestShowIDs(t *testing.T) {
-	si := newFakeShowIndex()
-
-	si.ids = showIdsIndex
-
-	expectedIDs := showIdsIndex
-	ids, err := si.IDs()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expectedIDs, ids) {
-		t.Errorf("TestIDs: not the same ids")
+	if seasonPath != expectedSeasonPath {
+		t.Errorf("expected season path to be %q, got %q", expectedSeasonPath, seasonPath)
 	}
 }

--- a/lib/video.go
+++ b/lib/video.go
@@ -1,17 +1,6 @@
 package polochon
 
-import (
-	"regexp"
-	"strings"
-
-	"github.com/Sirupsen/logrus"
-)
-
-// Regexp used for slugs by Movie and ShowEpisode objects
-var (
-	invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
-	whiteSpacePattern  = regexp.MustCompile(`\s+`)
-)
+import "github.com/Sirupsen/logrus"
 
 // Quality represents the qualities of a video
 type Quality string
@@ -44,16 +33,6 @@ type Video interface {
 	GetDetails(*logrus.Entry) error
 	GetTorrents(*logrus.Entry) error
 	GetSubtitle(*logrus.Entry) error
-	Slug() string
 	SetFile(f *File)
 	GetFile() *File
-}
-
-func slug(text string) string {
-	separator := "-"
-	text = strings.ToLower(text)
-	text = invalidSlugPattern.ReplaceAllString(text, "")
-	text = whiteSpacePattern.ReplaceAllString(text, separator)
-	text = strings.Trim(text, separator)
-	return text
 }

--- a/lib/video_test.go
+++ b/lib/video_test.go
@@ -23,17 +23,3 @@ func TestIsAllowedQuality(t *testing.T) {
 		}
 	}
 }
-
-func TestSlug(t *testing.T) {
-	for expected, s := range map[string]string{
-		"abcd-lol-pwet-123":  "abcd (lol) pwet! [123]",
-		"abcd-lol-pwet-1234": "abcd-lol-pwet-1234",
-		"20-wt-o":            "é %20 w@t \\o/",
-	} {
-		got := slug(s)
-
-		if got != expected {
-			t.Errorf("Expected %q got %q", expected, got)
-		}
-	}
-}

--- a/token.exemple.yml
+++ b/token.exemple.yml
@@ -14,7 +14,8 @@
   include:
     - user
   allowed:
-    - DeleteByIDs
+    - DeleteMovies
+    - DeleteEpisode
   token:
   - name: skywalker
     value: owoifupqkjlknkn

--- a/token.exemple.yml
+++ b/token.exemple.yml
@@ -1,7 +1,6 @@
 - role: guest
   allowed:
     - MoviesListIDs
-    - ShowsListSlugs
   token:
   - name: toto
     value: wwiuiuwbjqwndjqubyuui
@@ -15,7 +14,7 @@
   include:
     - user
   allowed:
-    - DeleteBySlugs
+    - DeleteByIDs
   token:
   - name: skywalker
     value: owoifupqkjlknkn


### PR DESCRIPTION
*  Remove slugs from everywhere
* Update the show index format to support path
* Add a HTTP route to render show details
* Move video, show and movie indexes to seperate packages 
* Rename functions to match the new package names
* Add a HTTP route to delete movies and episodes