### PR TITLE
tvdb: Fix NotFound when no fanart

### DIFF
--- a/modules/tvdb/tvdb.go
+++ b/modules/tvdb/tvdb.go
@@ -264,6 +264,9 @@ func (t *TvDB) getShowImages(s *polochon.Show, show *tvdb.Series) error {
 	} {
 		// Fetch the image
 		if err := imageType.f(show); err != nil {
+			if tvdb.HaveCodeError(404, err) {
+				continue
+			}
 			return err
 		}
 


### PR DESCRIPTION
Sometimes there is no fanart or poster, we don't have to return an
error, just ignore the image and continue
It's best to have the Show informations without images than no infos at
all