### PR TITLE
Don't compress HTTP responses

### DIFF
--- a/app/server/routes.go
+++ b/app/server/routes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gorilla/mux"
 	negronilogrus "github.com/meatballhat/negroni-logrus"
 	"github.com/odwrtw/polochon/app/token"
-	"github.com/phyber/negroni-gzip/gzip"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 )
@@ -233,9 +232,6 @@ func (s *Server) httpServer(log *logrus.Entry) *http.Server {
 
 	// Use logrus as logger
 	n.Use(negronilogrus.NewMiddlewareFromLogger(s.log.Logger, "httpServer"))
-
-	// gzip compression
-	n.Use(gzip.Gzip(gzip.DefaultCompression))
 
 	// Add basic auth if configured
 	if s.config.HTTPServer.BasicAuth {


### PR DESCRIPTION
In order to have the correct length of the downloaded files
In the future, we should separate download endpoints from the rest, and
only disable compression on those endpoints