### PR TITLE
Fix staticcheck issues

### DIFF
--- a/app/app/app.go
+++ b/app/app/app.go
@@ -101,10 +101,10 @@ func (a *App) init() error {
 			log.Debug("loading auth manager configuration")
 
 			file, err := os.Open(a.authConfigPath)
-			defer file.Close()
 			if err != nil {
 				return err
 			}
+			defer file.Close()
 
 			authManager, err = auth.New(file)
 			if err != nil {

--- a/lib/library/library_test.go
+++ b/lib/library/library_test.go
@@ -19,7 +19,7 @@ func (m *mockInvalidType) GetFile() *polochon.File             { return &polocho
 func (m *mockInvalidType) GetSubtitlers() []polochon.Subtitler { return nil }
 func (m *mockInvalidType) GetDetailers() []polochon.Detailer   { return nil }
 func (m *mockInvalidType) GetTorrenters() []polochon.Torrenter { return nil }
-func (m *mockInvalidType) SetMetadata(*polochon.VideoMetadata) { return }
+func (m *mockInvalidType) SetMetadata(*polochon.VideoMetadata) {}
 func (m *mockInvalidType) SubtitlePath(lang polochon.Language) string {
 	return "path_" + string(lang)
 }

--- a/lib/papi/client.go
+++ b/lib/papi/client.go
@@ -49,7 +49,6 @@ func New(endpoint string) (*Client, error) {
 // SetToken sets the token
 func (c *Client) SetToken(token string) {
 	c.token = token
-	return
 }
 
 // SetBasicAuth set the basic auth details
@@ -58,8 +57,6 @@ func (c *Client) SetBasicAuth(username, password string) {
 		username: username,
 		password: password,
 	}
-
-	return
 }
 
 // GetDetails get the detailed informations of a resource

--- a/modules/pushover/pushover.go
+++ b/modules/pushover/pushover.go
@@ -111,7 +111,7 @@ func (p *Pushover) Notify(i interface{}, log *logrus.Entry) error {
 // Notify sends a movie notification
 func (p *Pushover) notifyMovie(movie *polochon.Movie) error {
 	message := &pushover.Message{
-		Title:    fmt.Sprintf("Canapé (Movie)"),
+		Title:    "Canapé (Movie)",
 		Message:  movie.Title,
 		URL:      fmt.Sprintf("imdb:///title/%s/", movie.ImdbID),
 		URLTitle: "Open on imdb",
@@ -156,7 +156,7 @@ func (p *Pushover) notifyMovie(movie *polochon.Movie) error {
 // Notify sends a show episode notification
 func (p *Pushover) notifyShowEpisode(show *polochon.ShowEpisode) error {
 	message := &pushover.Message{
-		Title:    fmt.Sprintf("Canapé (Show)"),
+		Title:    "Canapé (Show)",
 		Message:  fmt.Sprintf("%s - S%02dE%02d", show.ShowTitle, show.Season, show.Episode),
 		URL:      fmt.Sprintf("imdb:///title/%s/", show.ShowImdbID),
 		URLTitle: "Open on imdb",


### PR DESCRIPTION
app/app/app.go:104:4: should check returned error before deferring file.Close() (SA5001)
lib/library/library_test.go:22:66: redundant return statement (S1023)
lib/papi/client.go:52:2: redundant return statement (S1023)
lib/papi/client.go:62:2: redundant return statement (S1023)
modules/pushover/pushover.go:114:13: unnecessary use of fmt.Sprintf (S1039)
modules/pushover/pushover.go:159:13: unnecessary use of fmt.Sprintf (S1039)