### PR TITLE
Remove the tokens from the logs

### DIFF
--- a/app/auth/manager.go
+++ b/app/auth/manager.go
@@ -92,16 +92,18 @@ func (m *Manager) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// IsAllowed return true if the given route name is allowed with
-// the given token's value
-func (m *Manager) IsAllowed(token, route string) bool {
+// IsAllowed checks if the given route is allowed with the given token
+func (m *Manager) IsAllowed(token, route string) (string, bool) {
 	t, ok := m.tokens[token]
 	if !ok {
-		return false
+		return "", false
 	}
 
 	_, ok = t.routeMap[route]
-	return ok
+	if !ok {
+		return "", false
+	}
+	return t.name, ok
 }
 
 // GetAllowed returns the allowed routes names for a token

--- a/app/auth/manager_test.go
+++ b/app/auth/manager_test.go
@@ -101,10 +101,11 @@ func TestIsAllowed(t *testing.T) {
 	}
 
 	tt := []struct {
-		name     string
-		token    string
-		route    string
-		expected bool
+		name              string
+		token             string
+		route             string
+		expected          bool
+		expectedTokenName string
 	}{
 		{
 			name:     "invalid token on user routes",
@@ -113,10 +114,11 @@ func TestIsAllowed(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "guest on guest routes",
-			token:    "guest1token",
-			route:    "MoviesListIDs",
-			expected: true,
+			name:              "guest on guest routes",
+			token:             "guest1token",
+			route:             "MoviesListIDs",
+			expected:          true,
+			expectedTokenName: "guest1",
 		},
 		{
 			name:     "guest on user routes",
@@ -125,10 +127,11 @@ func TestIsAllowed(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "user on user routes",
-			token:    "user1token",
-			route:    "TorrentsAdd",
-			expected: true,
+			name:              "user on user routes",
+			token:             "user1token",
+			route:             "TorrentsAdd",
+			expected:          true,
+			expectedTokenName: "user1",
 		},
 		{
 			name:     "user on admin routes",
@@ -137,18 +140,24 @@ func TestIsAllowed(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "admin on admin routes",
-			token:    "admin1token",
-			route:    "DeleteEpisode",
-			expected: true,
+			name:              "admin on admin routes",
+			token:             "admin1token",
+			route:             "DeleteEpisode",
+			expected:          true,
+			expectedTokenName: "admin1",
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			allowed := manager.IsAllowed(tc.token, tc.route)
+			tokenName, allowed := manager.IsAllowed(tc.token, tc.route)
 			if allowed != tc.expected {
 				t.Fatalf("expected %t, got %t", tc.expected, allowed)
+			}
+
+			if tokenName != tc.expectedTokenName {
+				t.Fatalf("invalid token name expected %q, got %q",
+					tc.expectedTokenName, tokenName)
 			}
 		})
 	}

--- a/app/auth/middleware.go
+++ b/app/auth/middleware.go
@@ -1,10 +1,17 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gorilla/mux"
 )
+
+// CtxKey is a type of context key
+type CtxKey string
+
+// TokenName is the key used in the context
+const TokenName CtxKey = "auth-token-name"
 
 // Middleware used for check the token and access rigth
 type Middleware struct {
@@ -41,10 +48,13 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 		return
 	}
 
-	if !m.manager.IsAllowed(token, routeName) {
+	name, ok := m.manager.IsAllowed(token, routeName)
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
 
-	next(w, r)
+	ctx := context.WithValue(r.Context(), TokenName, name)
+
+	next(w, r.WithContext(ctx))
 }

--- a/app/server/logrus_middleware.go
+++ b/app/server/logrus_middleware.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/odwrtw/polochon/app/auth"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/negroni"
+)
+
+func logFieldsFromRequest(r *http.Request) logrus.Fields {
+	// Try to get the real IP
+	remoteAddr := r.RemoteAddr
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		remoteAddr = realIP
+	}
+
+	return logrus.Fields{
+		"request": r.RequestURI,
+		"method":  r.Method,
+		"remote":  remoteAddr,
+	}
+}
+
+type logrusMiddleware struct {
+	logger *logrus.Logger
+}
+
+func newLogrusMiddleware(logger *logrus.Logger) *logrusMiddleware {
+	return &logrusMiddleware{
+		logger: logger,
+	}
+}
+
+func (lm *logrusMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
+
+	entry := logrus.NewEntry(lm.logger)
+	entry = entry.WithFields(logFieldsFromRequest(r))
+
+	entry.Info("started handling request")
+
+	next(rw, r)
+
+	res := rw.(negroni.ResponseWriter)
+	entry = entry.WithFields(logrus.Fields{
+		"status":      res.Status(),
+		"text_status": http.StatusText(res.Status()),
+		"took":        time.Since(start),
+		"size_byte":   res.Size(),
+	})
+
+	tokenName, ok := r.Context().Value(auth.TokenName).(string)
+	if ok {
+		entry = entry.WithField("token_name", tokenName)
+	}
+
+	entry.Info("completed handling request")
+}
+
+type logrusAuthMiddleware struct {
+	logger *logrus.Logger
+}
+
+func newLogrusAuthMiddleware(logger *logrus.Logger) *logrusAuthMiddleware {
+	return &logrusAuthMiddleware{
+		logger: logger,
+	}
+}
+
+func (lam *logrusAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	tokenName, ok := r.Context().Value(auth.TokenName).(string)
+	if ok {
+		logrus.
+			NewEntry(lam.logger).
+			WithFields(logFieldsFromRequest(r)).
+			WithField("token_name", tokenName).
+			Info("authorized")
+	}
+
+	next(rw, r)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/kolo/xmlrpc v0.0.0-20190417161013-de6d879202d7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28 // indirect
-	github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/odwrtw/addicted v0.0.0-20200509145452-a5d36bf9d0f8

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP7EJk=
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
@@ -9,7 +8,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
-github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
@@ -78,8 +76,6 @@ github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28/go.mod h1:T/T7
 github.com/mailru/easyjson v0.0.0-20180730094502-03f2033d19d5/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f h1:V6GHkMOIsnpGDasS1iYiNxEYTY8TmyjQXEF8PqYkKQ8=
-github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f/go.mod h1:Ylx55XGW4gjY7McWT0pgqU0aQquIOChDnYkOVbSuF/c=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -165,7 +161,6 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/lib/papi/client_test.go
+++ b/lib/papi/client_test.go
@@ -10,32 +10,24 @@ import (
 	polochon "github.com/odwrtw/polochon/lib"
 )
 
-func TestURLWithToken(t *testing.T) {
-	c, err := New("http://mock.url")
+func TestTokenAuth(t *testing.T) {
+	var foundToken string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		foundToken = r.Header.Get("X-Auth-Token")
+	}))
+	defer ts.Close()
+
+	c, err := New(ts.URL)
 	if err != nil {
 		t.Fatalf("invalid endpoint: %q", err)
 	}
 	c.SetToken("token1")
 
-	for _, test := range []struct {
-		ExpectedURL string
-		URL         string
-		ExpectedErr error
-	}{
-		{
-			ExpectedURL: "http://mock.url/test?token=token1",
-			URL:         "http://mock.url/test",
-			ExpectedErr: nil,
-		},
-	} {
-		got, err := c.url(test.URL)
-		if err != test.ExpectedErr {
-			t.Fatalf("expected err %q, got %q", test.ExpectedErr, err)
-		}
-
-		if got != test.ExpectedURL {
-			t.Fatalf("expected %q, got %q", test.ExpectedURL, got)
-		}
+	// Don't need to check the result of this call, the point is to get the
+	// header
+	c.GetMovies()
+	if foundToken != "token1" {
+		t.Fatalf("token not set in the header")
 	}
 }
 


### PR DESCRIPTION
* Update papi to use a http header instead of an URL value
* Update the auth middleware add the token name in the request's context
* Remove the deprecated negronilogrus package and replace it with a custom implementation
* Add a new middleware to log the token name associated with the http request